### PR TITLE
Jobs not failing on When.reject new Error

### DIFF
--- a/lib/control/worker.ctrl.js
+++ b/lib/control/worker.ctrl.js
@@ -419,7 +419,7 @@ Worker.prototype._workFinish = function( job, success, optErr, optDone ) {
   this.jobs.delete(job.id);
 
   // determine success
-  if (success == null) {
+  if (success === null) {
     success = !optErr;
     if (_.isBoolean(optErr) && !optErr) {
       success = false;


### PR DESCRIPTION
When the promise is rejected with an Error (not a string) the job is considered successful.

Check the following example:

``` coffee-script
When = require 'when'
kickq = require 'kickq'

kickq.process ['test'], concurrentJobs: 1, (job, data) ->
  When.reject new Error 'some error'

kickq.create('test', null, hotjob: true).then (job) ->
  job.hotjobPromise
.then ({name, complete, success, lastError}) ->
  console.log 'good:', {name, complete, success, lastError}
.then null, (err) ->
  console.log 'bad:', err
.then ->
  process.exit()
```

It prints

```
good: { name: 'test', complete: true, success: true, lastError: null }
```

Deleting `new Error` will result in failing the job.

Most `node.js` functions returns `Error` object and not a string. So, any `node.js` function wrapped with `when/node/function` will cause such a problem.
