### PR TITLE
Fixed lastError for wrapped errors.

### DIFF
--- a/lib/control/worker.ctrl.js
+++ b/lib/control/worker.ctrl.js
@@ -390,6 +390,8 @@ Worker.prototype._workStart = function( job ) {
  */
 Worker.prototype._workFinish = function( job, success, optErr, optDone ) {
   if (success) optErr = undefined;
+  if (optErr instanceof Error) optErr = optErr.message;
+
   log.fine('_workFinish() :: Init. jobId: ', job.id, ' Queue:', job.name +
     ' Error: ', optErr, ' processCount:', job._processCount);
 


### PR DESCRIPTION
In #6 I fixed `kickq` behavior on Errors, wrapped with `new Error`, but I forgot that such Errors won't survive JSON serialization.
Here is the fix for it.
