### PR TITLE
Support node.js 0.12.x

### DIFF
--- a/lib/utility/klogger.js
+++ b/lib/utility/klogger.js
@@ -8,7 +8,7 @@ var fs = require('fs');
 var util = require('util');
 
 var _ = require('underscore');
-var syslog = require('node-syslog');
+var syslog = require('strong-fork-syslog');
 var logg = require('logg');
 
 var kconfig = require('./config');

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yaml": "~0.2.3",
     "underscore": "~1.7.0",
     "when": "~1.8.1",
-    "node-syslog": "~1.1.7",
+    "strong-fork-syslog": "~1.2.3",
     "profy": "0.0.5",
     "logg": "^0.3.0",
     "redis": "^0.12.1"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "underscore": "~1.7.0",
     "when": "~1.8.1",
     "strong-fork-syslog": "~1.2.3",
-    "profy": "0.0.5",
     "logg": "^0.3.0",
     "redis": "^0.12.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "main": "lib/kickq.main.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha -b test/spec -u tdd -R spec"


### PR DESCRIPTION
Currently `kickq` do not support `node.js 0.12.x`.

Here is the list of `kickq` deps without `node.js 0.12.x` support:

 * node-syslog
 * memwatch
 * profiler
 * profy
 * nodetime

Fortunately, almost all of them are `devDependencies` used only for stress testing.

To fix compatibility problems I replaced deprecated `node-syslog` module with its actively developed [strong-fork-syslog] fork.

With this patch `kickq` should work fine with `node.js 0.12.x`. I runt all tests and they worked fine (except for `stress.test.js`, which is incompatible with `node.js 0.12.x`).

The only drawback of this patch is that `node.js 0.8.x` is no longer supported.

  [strong-fork-syslog]: https://www.npmjs.com/package/strong-fork-syslog