### PR TITLE
Remove dev dependencies from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,16 @@
+kickq-*.tgz
+
+.editorconfig
+.gitattributes
+.gitignore
+.gitmodules
+.jshintrc
+.npmignore
+.travis.yml
+
+Gruntfile.js
+
+config/
+tasks/
+temp/
+test/

--- a/package.json
+++ b/package.json
@@ -31,25 +31,25 @@
     "test": "./node_modules/.bin/mocha -b test/spec -u tdd -R spec"
   },
   "dependencies": {
-    "async": "~0.9.0",
     "collections": "~1.2.2",
-    "config": "~1.12.0",
-    "grunt": "~0.4.5",
     "logg": "^0.3.0",
     "node-syslog": "^1.2.0",
     "redis": "^0.12.1",
     "underscore": "~1.8.3",
-    "when": "~1.8.1",
-    "yaml": "~0.2.3"
+    "when": "~1.8.1"
   },
   "devDependencies": {
+    "async": "~0.9.0",
+    "config": "~1.12.0",
     "sinon": "~1.14.1",
+    "grunt": "~0.4.5",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-clean": "~0.6.0",
     "chai": "~2.2.0",
     "profy": "~0.1.1",
     "grunt-release": "~0.12.0",
-    "mocha": "^2.2.4"
+    "mocha": "^2.2.4",
+    "yaml": "~0.2.3"
   },
   "keywords": [
     "queue",


### PR DESCRIPTION
Right now `kickq` comes [with the bunch of dev dependencies][1] (i.e. `grunt`). Since all those deps are listed in `dependencies` instead of `devDependencies`, npm includes them to every `kickq` installation. But I'm pretty sure that `kickq` will work fine without them.

  [1]: https://github.com/verbling/kickq/blob/master/package.json#L33-L44